### PR TITLE
Fix bare variables in *with_* loops

### DIFF
--- a/ansible/tasks/main.yml
+++ b/ansible/tasks/main.yml
@@ -4,8 +4,8 @@
 - name: "Ansible: package dependencies"
   apt: name="{{item}}" state=present update_cache=yes cache_valid_time=86400
   with_items:
-    - python-pip
-    - python-dev
+    - "{{python-pip}}"
+    - "{{python-dev}}"
     
 - name: "Ansible: install via pip"    
   pip: name="ansible" state=present
@@ -13,8 +13,8 @@
 - name: "Ansible: remove build tools"
   apt: name="{{item}}" state=absent purge=yes
   with_items:
-    - python-dev
-    - build-essential
+    - "{{python-dev}}"
+    - "{{build-essential}}"
     
 - name: "Ansible: remove other build tools"
   command: apt-get -y autoremove

--- a/ansible/tests/playbook.yml
+++ b/ansible/tests/playbook.yml
@@ -3,6 +3,6 @@
 
 - name: "Ansible Test"
   hosts: all
-  sudo: true
+  become: true
   roles:
     - { role: ../../ansible, tags: ansible }

--- a/authprogs_config/tests/playbook.yml
+++ b/authprogs_config/tests/playbook.yml
@@ -2,7 +2,7 @@
 
 - name: Authprogs Test Install and Configuration
   hosts: all
-  sudo: true
+  become: true
   roles:
     - { role: ../../authprogs_install, tags: authprogs_install }
     - { role: ../../authprogs_config, tags: authprogs_config }

--- a/csf_action/tasks/main.yml
+++ b/csf_action/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
 - command: csf -ta {{item.ip}} {{item.ttl}} {{"-d %s"|format(item.direction) if item.direction is defined}} {{"-p %s"|format(item.port) if item.port is defined}} {{item.comment|default('Ansible')}}
-  with_items: csf_actions
+  with_items: "{{csf_actions}}"
   when: "'{{item.action}}' == 'temp_add'"
   

--- a/csf_config/tasks/main.yml
+++ b/csf_config/tasks/main.yml
@@ -95,7 +95,7 @@
     regexp: '^LF_{{item.name}} ='
     line: 'LF_{{item.name}} = "{{item.limit}}"'
   with_items:
-    csf_config_lfd_blocks
+    "{{csf_config_lfd_blocks}}"
   notify:
     - restart lfd
   tags:
@@ -118,7 +118,7 @@
     regexp: '^{{item.name}}_LOG ='
     line: '{{item.name}}_LOG = "{{item.file}}"'
   with_items:
-    csf_config_logs
+    "{{csf_config_logs}}"
   notify:
     - restart lfd
       
@@ -128,7 +128,7 @@
     regexp: '^{{item.name}}_LOG ='
     line: '{{item.name}}_LOG = "{{item.file}}"'
   with_items:
-    csf_config_logs_custom
+    "{{csf_config_logs_custom}}"
   notify:
     - restart lfd
 

--- a/csf_config/tests/playbook.yml
+++ b/csf_config/tests/playbook.yml
@@ -2,7 +2,7 @@
 
 - name: CSF (Config Server Security + Firewall) Test Install and Configuration
   hosts: all
-  sudo: true
+  become: true
   roles:
     - { role: ../../csf_install, tags: csf_install }
     - { role: ../../csf_config, tags: csf_config }

--- a/locale_install/tasks/main.yml
+++ b/locale_install/tasks/main.yml
@@ -3,7 +3,7 @@
     regexp: "{{item}}"
     line: "{{item}}"
   with_items:
-    locale_install_locales
+    "{{locale_install_locales}}"
   when: ansible_os_family == "Debian"
 
 - command: locale-gen

--- a/monit_config/tasks/main.yml
+++ b/monit_config/tasks/main.yml
@@ -22,5 +22,5 @@
 
 - name: Monit Configure services
   template: src={{item.template|default('default.j2')}} dest={{item.filename}}
-  with_items: monit_services
+  with_items: "{{monit_services}}"
   notify: restart monit

--- a/monit_config/tests/info.yml
+++ b/monit_config/tests/info.yml
@@ -1,5 +1,5 @@
 - name: Monit Info
-  sudo: yes
+  become: yes
   fetch: src={{item}} dest={{info_dest|default('site_info/')}}
   with_items:
     - "/etc/monit/monitrc"

--- a/monit_config/tests/playbook.yml
+++ b/monit_config/tests/playbook.yml
@@ -2,7 +2,7 @@
 
 - name: Monit Test Install
   hosts: all
-  sudo: true
+  become: true
   roles:
     - { role: ../../monit_install, tags: monit_install }
   tasks:
@@ -11,7 +11,7 @@
         
 - name: Monit Test Configuration
   hosts: all
-  sudo: true
+  become: true
   vars:
     monit_has_apache: true
     monit_services:

--- a/net_nat/tasks/main.yml
+++ b/net_nat/tasks/main.yml
@@ -1,7 +1,7 @@
 - name: Net if-up.d/nat
-  sudo: yes
+  become: yes
   template: src=net_nat_up.j2 dest=/etc/network/if-up.d/nat mode=0755
 
 - name: Net if-down.d/nat
-  sudo: yes
+  become: yes
   template: src=net_nat_down.j2 dest=/etc/network/if-down.d/nat mode=0755

--- a/postfix_config/tests/info.yml
+++ b/postfix_config/tests/info.yml
@@ -1,7 +1,7 @@
 - hosts: all
   name: Postfix Info
   gather_facts: no
-  sudo: yes
+  become: yes
   tasks:
     - name: Fetch config files
       sudo: yes

--- a/postfix_config/tests/playbook.yml
+++ b/postfix_config/tests/playbook.yml
@@ -2,7 +2,7 @@
 
 - name: Postfix Test Install and Configuration
   hosts: all
-  sudo: true
+  become: true
   roles:
     - { role: ../../postfix_install, tags: postfix_install }
     - { role: ../../postfix_config, tags: postfix_config }

--- a/ssh_config/tests/playbook.yml
+++ b/ssh_config/tests/playbook.yml
@@ -2,6 +2,6 @@
 
 - name: SSH Test Config
   hosts: all
-  sudo: true
+  become: true
   roles:
     - { role: ../../ssh_config }

--- a/ssl_config/tasks/certificate.yml
+++ b/ssl_config/tasks/certificate.yml
@@ -4,13 +4,13 @@
   copy:
     src: "{{ssl_certificate_local_path}}/{{item.name}}.pem"
     dest: "{{ssl_path}}/{{item.name}}.pem"
-  with_items: ssl_items
+  with_items: "{{ssl_items}}"
   when: "'{{item.state}}' == 'certificate'"
 
 - name: Key match
   shell: (openssl rsa -noout -in {{ssl_path}}/{{item.name}}.key | openssl md5 ; openssl x509 -noout -in {{ssl_path}}/{{item.name}}.pem | openssl md5) | uniq
   register: result
-  with_items: ssl_items
+  with_items: "{{ssl_items}}"
   when: "'{{item.state}}' == 'certificate'"
   changed_when: false
   failed_when: result.stdout_lines|length > 1

--- a/ssl_config/tasks/delete.yml
+++ b/ssl_config/tasks/delete.yml
@@ -4,19 +4,19 @@
   file:
     path: "{{ssl_path}}/{{item.name}}.key"
     state: absent
-  with_items: ssl_items
+  with_items: "{{ssl_items}}"
   when: "'{{item.state}}' == 'deleted'"
 
 - name: Delete csr
   file:
     path: "{{ssl_path}}/{{item.name}}.csr"
     state: absent
-  with_items: ssl_items
+  with_items: "{{ssl_items}}"
   when: "'{{item.state}}' == 'deleted' or '{{item.state}}' == 'key'"
   
 - name: Delete cnf
   file:
     path: "{{ssl_path}}/{{item.name}}.cnf"
     state: absent
-  with_items: ssl_items
+  with_items: "{{ssl_items}}"
   when: "'{{item.state}}' == 'deleted' or '{{item.state}}' == 'key'"

--- a/ssl_config/tasks/request.yml
+++ b/ssl_config/tasks/request.yml
@@ -4,32 +4,32 @@
   command: openssl genrsa -out "{{ssl_path}}/{{item.name}}.key" "{{item.key_size | default('2048')}}"
   args:
     creates: "{{ssl_path}}/{{item.name}}.key"
-  with_items: ssl_items
+  with_items: "{{ssl_items}}"
   when: "'{{item.state}}' == 'request' or '{{item.state}}' == 'selfsign'"
 
 - name: Create new request config file
   template:
     src: openssl.j2
     dest: "{{ssl_path}}/{{item.name}}.cnf"
-  with_items: ssl_items
+  with_items: "{{ssl_items}}"
   when: "'{{item.state}}' == 'request' or '{{item.state}}' == 'selfsign'"
 
 - name: Create new request
   command: openssl req -new -key {{ssl_path}}/{{item.name}}.key -out {{ssl_path}}/{{item.name}}.csr -subj "/C={{item.request.country_code}}/ST={{item.request.state}}/L={{item.request.locality}}/O={{item.request.organization}}/CN={{item.request.common_name}}" -config {{ssl_path}}/{{item.name}}.cnf {{item.request.flags | default('-sha256')}}
   #args:
   #  creates: {{ssl_request_request_file}}
-  with_items: ssl_items
+  with_items: "{{ssl_items}}"
   when: "'{{item.state}}' == 'request' or '{{item.state}}' == 'selfsign'"
 
 - name: Download requests
   fetch: src={{ssl_path}}/{{item.name}}.csr dest=site_info/{{inventory_hostname}}/ssl/ flat=true
-  with_items: ssl_items
+  with_items: "{{ssl_items}}"
   when: "'{{item.state}}' == 'request' or '{{item.state}}' == 'selfsign'"
 
 - name: Summary
-  sudo: false
+  become: false
   local_action: shell openssl req -text -in site_info/{{inventory_hostname}}/ssl/{{item.name}}.csr | grep -v '\(:\w\w:$\)\|\(\w\w:\w\w$\)' | head -n 18 > site_info/{{inventory_hostname}}/ssl/{{item.name}}.csr.txt
-  with_items: ssl_items
+  with_items: "{{ssl_items}}"
   when: "'{{item.state}}' == 'request' or '{{item.state}}' == 'selfsign'"
   changed_when: false
   tags:

--- a/ssl_config/tasks/sign.yml
+++ b/ssl_config/tasks/sign.yml
@@ -2,10 +2,10 @@
 
 - name: Self sign certificate
   command: openssl x509 -req -days {{item.days|default(3650)}} -in {{ssl_path}}/{{item.name}}.csr -signkey {{ssl_path}}/{{item.name}}.key -out {{ssl_path}}/{{item.name}}.pem {{item.sign.flags | default('-sha256')}}
-  with_items: ssl_items
+  with_items: "{{ssl_items}}"
   when: "'{{item.state}}' == 'selfsign'"
 
 - name: Download certificate
   fetch: src="{{ssl_path}}/{{item.name}}.pem" dest="{{ssl_certificate_local_path}}/{{item.name}}.pem" flat=true
-  with_items: ssl_items
+  with_items: "{{ssl_items}}"
   when: "'{{item.state}}' == 'selfsign'"

--- a/ssl_config/tests/playbook.yml
+++ b/ssl_config/tests/playbook.yml
@@ -2,6 +2,6 @@
 
 - name: SSL Test Configuration
   hosts: all
-  sudo: true
+  become: true
   roles:
     - { role: ../../ssl_config, tags: ssl_config }

--- a/tunnel/tests/playbook.yml
+++ b/tunnel/tests/playbook.yml
@@ -2,6 +2,6 @@
 
 - name: Tunnel Test Configuration
   hosts: all
-  sudo: true
+  become: true
   roles:
     - { role: ../../tunnel, tags: tunnel_config }


### PR DESCRIPTION
Bare variables in _with__ loops will be deprecated in Ansible 2.2, so enclosing them in braces to remove the current Ansible 2.1 warnings.
- Also updated `sudo` calls to `become`
