### PR TITLE
authprogs: replace "copyv" with "copy"

### DIFF
--- a/authprogs_config/tasks/main.yml
+++ b/authprogs_config/tasks/main.yml
@@ -1,8 +1,7 @@
-#- name: Authprogs Configuration
-#  copyv: src="site_files/{{inventory_hostname}}/root/.ssh/authprogs.conf"  dest="/root/.ssh/"
-  
-- name: Authprogs Configuration
-  copyv: src="site_files/{{inventory_hostname}}/root/.ssh/authprogs.yaml"  dest="/root/.ssh/"
+---
 
-- name: Authprogs Keys
-  copyv: src="site_files/{{inventory_hostname}}/root/.ssh/authorized_keys" dest="/root/.ssh/"
+- name: "Authprogs Configuration"
+  copy: src="site_files/{{inventory_hostname}}/root/.ssh/authprogs.yaml"  dest="/root/.ssh/"
+
+- name: "Authprogs Keys"
+  copy: src="site_files/{{inventory_hostname}}/root/.ssh/authorized_keys" dest="/root/.ssh/"

--- a/authprogs_install/tasks/main.yml
+++ b/authprogs_install/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 
-- name: Authprogs Install Pre-requisites
+- name: "Authprogs Install Pre-requisites"
   apt: package=git state=present
 
 - git:


### PR DESCRIPTION
copyv is superceded by copy in Ansible 2.2.X

This is our minimum supported version of Ansible now