### PR TITLE
Add dyndns support to csf role

### DIFF
--- a/csf_config/defaults/main.yml
+++ b/csf_config/defaults/main.yml
@@ -58,6 +58,14 @@ csf_config_process_load_action: ""
 csf_config_process_forkbomb: 0
 csf_config_process_sshdhung: 0
 
+csf_config_dyndns: 0
+csf_config_dyndns_ignore: 0
+csf_dyndns_allow:
+  - protocol: "tcp"
+    direction: "out"
+    port: "d=443"
+    domain: "d=example.com"
+
 csf_config_lfd_interval: 600
 csf_config_lfd_blocks:
   - name: "SSHD"
@@ -67,9 +75,6 @@ csf_config_lfd_blocks:
     limit: 5
     time:  7200
   - name: "SMTPAUTH"
-    limit: 5
-    time:  7200
-  - name: "POP3D"
     limit: 5
     time:  7200
   - name: "POP3D"

--- a/csf_config/tasks/main.yml
+++ b/csf_config/tasks/main.yml
@@ -65,9 +65,12 @@
     - { regexp: '^PORTKNOCKING_ALERT =', line: 'PORTKNOCKING_ALERT = "{{csf_config_port_knocking.alert}}"' }
     - { regexp: '^ST_SYSTEM =', line: 'ST_SYSTEM = "{{csf_config_system.enabled}}"' }
     - { regexp: '^LF_WEBMIN_EMAIL_ALERT =', line: 'LF_WEBMIN_EMAIL_ALERT = "0"' }
+    - { regexp: '^DYNDNS =', line: 'DYNDNS = "{{csf_config_dyndns}}"' }
+    - { regexp: '^DYNDNS_IGNORE =', line: 'DYNDNS_IGNORE = "{{csf_config_dyndns_ignore}}"' }
     # - { regexp: '^', line: '' }
   notify:
     - restart lfd
+    - restart csf
   tags:
     - csf_conf
 
@@ -158,3 +161,15 @@
     src: regex.custom.pm
   notify:
     - restart lfd
+
+# dyndns
+- lineinfile: 
+    dest: /etc/csf/csf.dyndns
+    line: '{{item.protocol}}|{{item.direction}}|{{item.port}}|{{item.domain}}'
+  with_items:
+    "{{csf_dyndns_allow}}"
+  notify:
+    - restart lfd
+    - restart csf
+  tags:
+    - csf_dyndns


### PR DESCRIPTION
This can be used to provide a whole in the firewall for domains that have multiple IP addresses.